### PR TITLE
Chore: move color helper to util method

### DIFF
--- a/modules/components/button.jsx
+++ b/modules/components/button.jsx
@@ -1,20 +1,7 @@
 var React = require('react');
 var Radium = require('radium');
 var { StyleResolverMixin, BrowserStateMixin } = Radium;
-var color = require('color');
-
-// The darken method exposed by `color` darkens by relatively adjusting
-// the lightness by a percentage. For example, if a color `foo` has a
-// lightness of `50%`, `color(foo).darken(0.5)` converts the lightness to
-// `25%`. This function darkens by adjusting absolute darkness, like LESS
-// and Sass. Given the same color `foo`, `absoluteDarken(foo, 10)` will
-// convert the lightness to `40%`.
-var absoluteDarken = function (colorValue, value) {
-  var colorObj = color(colorValue);
-  var darkenedColor = colorObj.lightness(colorObj.hsl().l - value);
-
-  return darkenedColor.hexString();
-};
+var { absoluteDarken } = require('../util/color.js');
 
 var hoverBg = function (styles) {
   return absoluteDarken(styles.backgroundColor, 10);

--- a/modules/util/color.js
+++ b/modules/util/color.js
@@ -2,22 +2,6 @@ var color = require('color');
 
 module.exports = {};
 
-// Wraps color lighten method to take a hex value and return a hex value
-module.exports.lighten = function (colorValue, amount) {
-  var colorObj = color(colorValue);
-  var lightenedColor = colorObj.lighten(amount);
-
-  return lightenedColor.hexString();
-};
-
-// Wraps color darken method to take a hex value and return a hex value
-module.exports.lighten = function (colorValue, amount) {
-  var colorObj = color(colorValue);
-  var darkenedColor = colorObj.darken(amount);
-
-  return darkenedColor.hexString();
-};
-
 // The darken method exposed by `color` darkens by relatively adjusting
 // the lightness by a percentage. For example, if a color `foo` has a
 // lightness of `50%`, `color(foo).darken(0.5)` converts the lightness to

--- a/modules/util/color.js
+++ b/modules/util/color.js
@@ -1,0 +1,45 @@
+var color = require('color');
+
+module.exports = {};
+
+// Wraps color lighten method to take a hex value and return a hex value
+module.exports.lighten = function (colorValue, amount) {
+  var colorObj = color(colorValue);
+  var lightenedColor = colorObj.lighten(amount);
+
+  return lightenedColor.hexString();
+};
+
+// Wraps color darken method to take a hex value and return a hex value
+module.exports.lighten = function (colorValue, amount) {
+  var colorObj = color(colorValue);
+  var darkenedColor = colorObj.darken(amount);
+
+  return darkenedColor.hexString();
+};
+
+// The darken method exposed by `color` darkens by relatively adjusting
+// the lightness by a percentage. For example, if a color `foo` has a
+// lightness of `50%`, `color(foo).darken(0.5)` converts the lightness to
+// `25%`. This function darkens by adjusting absolute darkness, like LESS
+// and Sass. Given the same color `foo`, `absoluteDarken(foo, 10)` will
+// convert the lightness to `40%`.
+module.exports.absoluteDarken = function (colorValue, amount) {
+  var colorObj = color(colorValue);
+  var darkenedColor = colorObj.lightness(colorObj.hsl().l - amount);
+
+  return darkenedColor.hexString();
+};
+
+// The lighten method exposed by `color` lightens by relatively adjusting
+// the lightness by a percentage. For example, if a color `foo` has a
+// lightness of `50%`, `color(foo).lighten(0.5)` converts the lightness to
+// `75%`. This function darkens by adjusting absolute darkness, like LESS
+// and Sass. Given the same color `foo`, `absoluteLighten(foo, 10)` will
+// convert the lightness to `60%`.
+module.exports.absoluteLighten = function (colorValue, amount) {
+  var colorObj = color(colorValue);
+  var lightenedColor = colorObj.lightness(colorObj.hsl().l + amount);
+
+  return lightenedColor.hexString();
+};


### PR DESCRIPTION
This moves the `absoluteDarken` method to a util file `util/color.js` and adds a corresponding `absoluteLighten`. It also wraps `color.lighten` and `color.darken` so there are two new `lighten` and `darken` methods that take and return hex values.

/cc @alexlande, @aykayen, @colinmegill 