### PR TITLE
Feature: Add react style guide for examples

### DIFF
--- a/examples/app.jsx
+++ b/examples/app.jsx
@@ -2,6 +2,9 @@ var React = require('react');
 var Radium = require('radium');
 var { StyleResolverMixin, MatchMediaMixin, MatchMediaStore } = Radium;
 
+var ReactStyleGuide = require('react-style-guide');
+require('react-style-guide/react-style-guide.css');
+
 var RadiumBootstrap = require('../modules/index.js');
 
 var Container = RadiumBootstrap.Container;
@@ -37,7 +40,6 @@ var App = React.createClass({
 
     return (
       <main>
-
         <Container
           fluid={true}
           mediaQueries={this.state.mediaQueries}
@@ -214,7 +216,10 @@ var App = React.createClass({
           fluid={true}
           mediaQueries={this.state.mediaQueries}
         >
-          <p>
+
+          <ReactStyleGuide
+            title="Button"
+          >
             <Button>
               Default
             </Button>
@@ -260,9 +265,11 @@ var App = React.createClass({
             >
               Link
             </Button>
-          </p>
+          </ReactStyleGuide>
 
-          <p>
+          <ReactStyleGuide
+            title="Button Sizes"
+          >
             <Button
               size='large'
               >
@@ -288,9 +295,11 @@ var App = React.createClass({
               >
               Extra Small
             </Button>
-          </p>
+          </ReactStyleGuide>
 
-          <p>
+          <ReactStyleGuide
+            title="Block Level Buttons"
+          >
             <Button
               kind='primary'
               size='large'
@@ -298,18 +307,22 @@ var App = React.createClass({
             >
               Block Level
             </Button>
-          </p>
+          </ReactStyleGuide>
 
-          <p>
+          <ReactStyleGuide
+            title="Disabled Buttons"
+          >
             <Button
               kind='primary'
               disabled={true}
             >
               Disabled
             </Button>
-          </p>
+          </ReactStyleGuide>
 
-          <p>
+          <ReactStyleGuide
+            title="Active Buttons"
+          >
             <Button
               kind='primary'
               active={true}
@@ -324,7 +337,7 @@ var App = React.createClass({
               >
               Active
             </Button>
-          </p>
+          </ReactStyleGuide>
         </Container>
       </main>
     );

--- a/examples/webpack.config.js
+++ b/examples/webpack.config.js
@@ -24,7 +24,11 @@ module.exports = {
       },
       {
         test: /\.json$/,
-        loader: "json-loader"
+        loader: 'json-loader'
+      },
+      {
+        test: /\.css$/,
+        loaders: ['style-loader', 'css-loader']
       }
     ]
   }

--- a/package.json
+++ b/package.json
@@ -22,12 +22,16 @@
   "dependencies": {
     "color": "^0.7.3",
     "lodash": "^3.2.0",
+    "radium": "git://github.com/FormidableLabs/radium#e85c02d8c314ea4dacfd8955e18b5211f5ff302e",
     "react": "^0.12.2",
-    "radium": "git://github.com/FormidableLabs/radium#e85c02d8c314ea4dacfd8955e18b5211f5ff302e"
+    "react-style-guide": "^1.0.2"
   },
   "devDependencies": {
+    "css-loader": "^0.9.1",
     "json-loader": "^0.5.1",
     "jsx-loader": "^0.12.2",
+    "react-style-guide": "^1.0.1",
+    "style-loader": "^0.8.3",
     "webpack": "^1.5.3",
     "webpack-dev-server": "^1.7.0"
   }


### PR DESCRIPTION
This adds the `ReactStyleGuide` component I've been working on for style guide examples without the gnarly webpack raw loader + jsxTransformer + `eval` thing we're doing on the form components branch.

Much nicer!

![screen shot 2015-02-23 at 11 07 11 am](https://cloud.githubusercontent.com/assets/808159/6334892/685712a4-bb4c-11e4-8fd2-c451618578c4.png)
