### PR TITLE
Pass props down to all components

### DIFF
--- a/modules/components/button.jsx
+++ b/modules/components/button.jsx
@@ -199,21 +199,21 @@ var Button = React.createClass({
   },
 
   render: function () {
-    var TagName = this.props.tagName;
+    var { children, tagName: TagName, ...props } = this.props;
 
     var additionalModifiers = {
-      activeLink: this.props.active && this.props.kind === 'link'
+      activeLink: props.active && props.kind === 'link'
     };
 
     var styles = this.buildStyles(this.getStyles(), additionalModifiers);
 
     return (
       <TagName
+        {...props}
         {...this.getBrowserStateEvents()}
-        disabled={this.props.disabled}
         style={styles}
       >
-        {this.props.children}
+        {children}
       </TagName>
     );
   }

--- a/modules/components/col.jsx
+++ b/modules/components/col.jsx
@@ -63,12 +63,13 @@ var Col = React.createClass({
   },
 
   render: function () {
-    var styles = this.buildStyles(this.getStyles());
-    var TagName = this.props.tagName;
+    var { children, tagName: TagName, ...props } = this.props;
 
+    var styles = this.buildStyles(this.getStyles());
+    
     return (
-      <TagName style={styles}>
-        {this.buildChildren(this.props.children)}
+      <TagName {...props} style={styles}>
+        {this.buildChildren(children)}
       </TagName>
     );
   }

--- a/modules/components/container.jsx
+++ b/modules/components/container.jsx
@@ -49,12 +49,13 @@ var Container = React.createClass({
   },
 
   render: function () {
+    var { children, tagName: TagName, ...props } = this.props;
+
     var styles = this.buildStyles(this.getStyles());
-    var TagName = this.props.tagName;
 
     return (
-      <TagName style={styles}>
-        {this.props.children}
+      <TagName {...props} style={styles}>
+        { children }
       </TagName>
     );
   }

--- a/modules/components/form.jsx
+++ b/modules/components/form.jsx
@@ -29,11 +29,11 @@ var Form = React.createClass({
   },
 
   render: function () {
-    var TagName = this.props.tagName;
+    var { children, tagName: TagName, ...props } = this.props;
 
     return (
-      <TagName {...this.props}>
-        {this.buildChildren(this.props.children)}
+      <TagName {...props}>
+        {this.buildChildren(children)}
       </TagName>
     );
   }

--- a/modules/components/help-text.jsx
+++ b/modules/components/help-text.jsx
@@ -21,12 +21,16 @@ var HelpText = React.createClass({
   },
 
   render: function () {
+    var { children, value, tagName: TagName, ...props } = this.props;
+    
     var styles = this.buildStyles(this.getStyles());
-    var TagName = this.props.tagName;
 
     return (
-      <TagName style={styles}>
-        {this.props.value}
+      <TagName 
+        {...props} 
+        style={styles}
+      >
+        { value }
       </TagName>
     );
   }

--- a/modules/components/row.jsx
+++ b/modules/components/row.jsx
@@ -31,15 +31,19 @@ var Row = React.createClass({
   },
 
   render: function () {
+    var { children, tagName: TagName, ...props } = this.props
+
     var styles = this.buildStyles(this.getStyles());
-    var TagName = this.props.tagName;
 
     // TODO: Make global Clearfix variable/mixin/something.
 
     return (
-      <TagName style={styles}>
+      <TagName 
+        style={styles} 
+        {...props}
+      >
         <i style={{display: 'table'}}>{'\u0020'}</i>
-        {this.buildChildren(this.props.children)}
+        {this.buildChildren(children)}
         <i style={{clear: 'both', display: 'table'}}>{'\u0020'}</i>
       </TagName>
     );


### PR DESCRIPTION
Things like buttons weren't passing props to their root DOM node, so it was impossible to add click handlers and other attributes (such as ARIA's).

In a few cases I also explicitly destructure `children` out of props, because in certain cases (some inputs) passing children as both a prop and as children, causes React to render them twice. IN other cases I try and pull out attributes (such as `value`) which will actually get rendered incorrectly as an html attribute, which is presumably not what you want on a div/span/etc.

Let me know if there is anything you'd like tweaked or style issues, I didn't see a lint config, so I tried to say as consistent with the repo as I could.